### PR TITLE
Feature/end status variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
+# Reason for Forking
+
+We have an issue that on huge `Dockerfile`s, kaniko is `unpacking rootfs` for a long time and after `~15min 11sec` our CI marks the job as success (when kaniko is still unpacking the `rootfs`).
+
+As a quick workaround, we will implement a new environment variable that will be exported to the container and could be watched in a for loop by the GitLab CI job.
+
+## Psudo Code
+
+### Before
+
+The issue we have is the following:
+
+```yaml
+scripts:
+  - kaniko build ......   # Kaniko hangs here and after 15min 11sec job is marked as success 
+```
+
+### Desired
+
+```yaml
+scripts:
+  - kaniko build ......   # Kaniko hangs and the job is continuing to the next command
+  - while [[ "$KANIKO_STATUS" != "DONE" ]]
+```
+
 # kaniko - Build Images In Kubernetes
 
 ## 🚨NOTE: kaniko is not an officially supported Google product🚨

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -167,7 +167,8 @@ var RootCmd = &cobra.Command{
 		if err := executor.DoPush(image, opts); err != nil {
 			exit(errors.Wrap(err, "error pushing image"))
 		}
-
+		os.Setenv("KANIKO_STATUS", "DONE")
+		
 		benchmarkFile := os.Getenv("BENCHMARK_FILE")
 		// false is a keyword for integration tests to turn off benchmarking
 		if benchmarkFile != "" && benchmarkFile != "false" {


### PR DESCRIPTION
# Reason for Forking

We have an issue that on huge `Dockerfile`s, kaniko is `unpacking rootfs` for a long time and after `~15min 11sec` our CI marks the job as success (when kaniko is still unpacking the `rootfs`).

As a quick workaround, we will implement a new environment variable that will be exported to the container and could be watched in a for loop by the GitLab CI job.

## Psudo Code

### Before

The issue we have is the following:

```yaml
scripts:
  - kaniko build ......   # Kaniko hangs here and after 15min 11sec job is marked as success 
```

### Desired

```yaml
scripts:
  - kaniko build ......   # Kaniko hangs and the job is continuing to the next command
  - while [[ "$KANIKO_STATUS" != "DONE" ]]
```
